### PR TITLE
fix: gnl tester

### DIFF
--- a/.subjects/STUD_PART/exam_03/0/get_next_line/tester.sh
+++ b/.subjects/STUD_PART/exam_03/0/get_next_line/tester.sh
@@ -22,7 +22,7 @@ then
     rm traceback
 fi
 
-cp .subjects/STUD_PART/exam_03/1/get_next_line/test .
+cp .subjects/STUD_PART/exam_03/0/get_next_line/test .
 
 cd .system/grading
 cp test ../../rendu/test


### PR DESCRIPTION
Since #66 the tester for get_next_line broke. It was because the directory wasnt updated in the tester.