### PR TITLE
Added new testcase with trailing whitespace character

### DIFF
--- a/.subjects/STUD_PART/exam_02/1/union/subject.en.txt
+++ b/.subjects/STUD_PART/exam_02/1/union/subject.en.txt
@@ -1,0 +1,27 @@
+Assignment name  : union
+Expected files   : union.c
+Allowed functions: write
+--------------------------------------------------------------------------------
+
+Write a program that takes two strings and displays, without doubles, the
+characters that appear in either one of the strings.
+
+The display will be in the order characters appear in the command line, and
+will be followed by a \n.
+
+If the number of arguments is not 2, the program displays \n.
+
+Example:
+
+$>./union zpadinton "paqefwtdjetyiytjneytjoeyjnejeyj" | cat -e
+zpadintoqefwjy$
+$>./union ddf6vewg64f gtwthgdwthdwfteewhrtag6h4ffdhsd | cat -e
+df6vewg4thras$
+$>./union "rien" "cette phrase ne cache rien" | cat -e
+rienct phas$
+$>./union | cat -e
+$
+$>
+$>./union "rien" | cat -e
+$
+$>

--- a/.subjects/STUD_PART/exam_02/3/rostring/tester.sh
+++ b/.subjects/STUD_PART/exam_02/3/rostring/tester.sh
@@ -3,10 +3,10 @@
 #                                                         :::      ::::::::    #
 #    tester.sh                                          :+:      :+:    :+:    #
 #                                                     +:+ +:+         +:+      #
-#    By: pandalaf <pandalaf@student.42wolfsburg.    +#+  +:+       +#+         #
+#    By: jkulka <jkulka@student.42heilbronn.de >    +#+  +:+       +#+         #
 #                                                 +#+#+#+#+#+   +#+            #
 #    Created: 2022/11/07 00:45:37 by pandalaf          #+#    #+#              #
-#    Updated: 2022/11/07 01:41:49 by pandalaf         ###   ########.fr        #
+#    Updated: 2023/10/06 10:27:47 by jkulka           ###   ########.fr        #
 #                                                                              #
 # **************************************************************************** #
 
@@ -32,6 +32,12 @@ if [ -e .system/grading/traceback ];then
 fi
 
 bash .system/auto_correc_program.sh $FILE $ASSIGN "first" "2" "11000000"
+if [ -e .system/grading/traceback ];then
+	mv .system/grading/traceback .
+	exit 1
+fi
+
+bash .system/auto_correc_program.sh $FILE $ASSIGN "This is a test "
 if [ -e .system/grading/traceback ];then
 	mv .system/grading/traceback .
 	exit 1


### PR DESCRIPTION
I added this case after noticing that i still would pass without a whitespace between the last word and the word before this should fix it.