### PR TITLE
Exam05 - Fix/compilation 

### DIFF
--- a/.subjects/STUD_PART/exam_05/0/cpp_module00/tester.sh
+++ b/.subjects/STUD_PART/exam_05/0/cpp_module00/tester.sh
@@ -3,15 +3,15 @@
 #                                                         :::      ::::::::    #
 #    tester.sh                                          :+:      :+:    :+:    #
 #                                                     +:+ +:+         +:+      #
-#    By: jcluzet <jcluzet@student.42.fr>            +#+  +:+       +#+         #
+#    By: tfregni <tfregni@student.42berlin.de>      +#+  +:+       +#+         #
 #                                                 +#+#+#+#+#+   +#+            #
 #    Created: 2021/06/20 02:26:11 by jcluzet           #+#    #+#              #
-#    Updated: 2022/09/01 23:50:56 by jcluzet          ###   ########.fr        #
+#    Updated: 2023/11/05 01:00:46 by tfregni          ###   ########.fr        #
 #                                                                              #
 # **************************************************************************** #
 
 MAIN='main.cpp'
-MAIN1='../.system/grading/main.cpp'
+MAIN1='cpp_module00/main.cpp'
 
 index=0
 
@@ -24,10 +24,12 @@ cd .system/grading
 clang++ -Wall -Wextra -Werror -std=c++98 -o source $MAIN Warlock.cpp
 ./source | cat -e > sourcexam       #TESTING
 rm source
+cp main.cpp ../../rendu/cpp_module00
 cd ../../rendu
 {
 clang++ -Wall -Wextra -Werror -std=c++98 -o final $MAIN1 cpp_module00/Warlock.cpp
 }  &>../.system/grading/traceback
+rm -f cpp_module00/main.cpp
 # if there is a traceback file, exit this script
 # if [ -e ../.system/grading/traceback ]
 # then

--- a/.subjects/STUD_PART/exam_05/1/cpp_module01/tester.sh
+++ b/.subjects/STUD_PART/exam_05/1/cpp_module01/tester.sh
@@ -3,15 +3,15 @@
 #                                                         :::      ::::::::    #
 #    tester.sh                                          :+:      :+:    :+:    #
 #                                                     +:+ +:+         +:+      #
-#    By: jcluzet <jcluzet@student.42.fr>            +#+  +:+       +#+         #
+#    By: tfregni <tfregni@student.42berlin.de>      +#+  +:+       +#+         #
 #                                                 +#+#+#+#+#+   +#+            #
 #    Created: 2021/06/20 02:26:11 by jcluzet           #+#    #+#              #
-#    Updated: 2022/09/01 23:52:05 by jcluzet          ###   ########.fr        #
+#    Updated: 2023/11/05 00:49:45 by tfregni          ###   ########.fr        #
 #                                                                              #
 # **************************************************************************** #
 
 MAIN='main.cpp'
-MAIN1='../.system/grading/main.cpp'
+MAIN1='cpp_module01/main.cpp'
 
 index=0
 
@@ -24,10 +24,12 @@ cd .system/grading
 clang++ -Wall -Wextra -Werror -std=c++98 -o source Warlock.cpp ASpell.cpp ATarget.cpp Dummy.cpp Fwoosh.cpp $MAIN
 ./source | cat -e > sourcexam       #TESTING
 rm source
+cp main.cpp ../../rendu/cpp_module01
 cd ../../rendu
 {
 clang++ -Wall -Wextra -Werror -std=c++98 -o final cpp_module01/Warlock.cpp cpp_module01/ASpell.cpp cpp_module01/ATarget.cpp cpp_module01/Dummy.cpp cpp_module01/Fwoosh.cpp $MAIN1
 }  &>../.system/grading/traceback
+rm -f cpp_module01/main.cpp
 # if there is a traceback file, exit this script
 # if [ -e ../.system/grading/traceback ]
 # then

--- a/.subjects/STUD_PART/exam_05/2/cpp_module02/tester.sh
+++ b/.subjects/STUD_PART/exam_05/2/cpp_module02/tester.sh
@@ -3,15 +3,15 @@
 #                                                         :::      ::::::::    #
 #    tester.sh                                          :+:      :+:    :+:    #
 #                                                     +:+ +:+         +:+      #
-#    By: jcluzet <jcluzet@student.42.fr>            +#+  +:+       +#+         #
+#    By: tfregni <tfregni@student.42berlin.de>      +#+  +:+       +#+         #
 #                                                 +#+#+#+#+#+   +#+            #
 #    Created: 2021/06/20 02:26:11 by jcluzet           #+#    #+#              #
-#    Updated: 2022/09/04 21:15:51 by jcluzet          ###   ########.fr        #
+#    Updated: 2023/11/05 00:51:20 by tfregni          ###   ########.fr        #
 #                                                                              #
 # **************************************************************************** #
 
 MAIN='main.cpp'
-MAIN1='../.system/grading/main.cpp'
+MAIN1='cpp_module02/main.cpp'
 
 index=0
 
@@ -24,10 +24,12 @@ cd .system/grading
 clang++ -Wall -Wextra -Werror -std=c++98 -o source Warlock.cpp ASpell.cpp ATarget.cpp BrickWall.cpp Dummy.cpp Fireball.cpp Fwoosh.cpp Polymorph.cpp SpellBook.cpp TargetGenerator.cpp $MAIN
 ./source | cat -e > sourcexam       #TESTING
 rm source
+cp main.cpp ../../rendu/cpp_module02
 cd ../../rendu
 {
 clang++ -Wall -Wextra -Werror -std=c++98 -o final cpp_module02/Warlock.cpp cpp_module02/ASpell.cpp cpp_module02/ATarget.cpp cpp_module02/BrickWall.cpp cpp_module02/Dummy.cpp cpp_module02/Fireball.cpp cpp_module02/Fwoosh.cpp cpp_module02/Polymorph.cpp cpp_module02/SpellBook.cpp cpp_module02/TargetGenerator.cpp $MAIN1
 }  &>../.system/grading/traceback
+rm -f cpp_module01/main.cpp
 # if there is a traceback file, exit this script
 # if [ -e ../.system/grading/traceback ]
 # then


### PR DESCRIPTION
The main.cpp used for testing includes hpp files in its folder, but that forces the provided code to have the same declarations while some const or & can be arbitrary, as long as the test cases work. 
That's why some solutions that pass the actual exam in 42 would not compile on the simulator.
I suggest to copy the test main in the rendu/cpp_module0x and compile with the provided hpp files.