### PR TITLE
bugfix #144: make exam06 compatible with MacOS

### DIFF
--- a/.subjects/STUD_PART/exam_06/0/mini_serv/catchmsg.sh
+++ b/.subjects/STUD_PART/exam_06/0/mini_serv/catchmsg.sh
@@ -2,7 +2,6 @@
 
 # close fd before init
 exec 6<&-
-nc localhost $1
 exec 6</dev/tcp/localhost/"$1"
 
 while read -r <&6

--- a/.subjects/STUD_PART/exam_06/0/mini_serv/findport.sh
+++ b/.subjects/STUD_PART/exam_06/0/mini_serv/findport.sh
@@ -10,12 +10,18 @@ if [ -z "$last_port" ]
 then
         last_port=9999
 fi
-function scanner
 
+if [ $(uname) == "Darwin" ]; then
+	checkport_tool='lsof -i -n -P'
+else
+	checkport_tool='ss -tuln'
+fi
+
+function scanner
 {
 for ((port="$first_port"; port<="$last_port"; port++))
         do
-            checkport=`ss -tuln | grep $port`
+            checkport=`eval $checkport_tool | grep $port`
             if [ -z "$checkport" ]; then
                 goodport=$port
                 break

--- a/.subjects/STUD_PART/exam_06/0/mini_serv/test_eof.sh
+++ b/.subjects/STUD_PART/exam_06/0/mini_serv/test_eof.sh
@@ -1,4 +1,10 @@
+if [ $(uname) == "Darwin" ]; then
+	nc_command="nc localhost $1"
+else
+	nc_command="nc -q 0 localhost $1"
+fi
+
 for x in `cat eof_test`; do
   printf $x
   sleep 0.1
-done | nc -q 0 localhost $1
+done | eval $nc_command

--- a/.subjects/STUD_PART/exam_06/0/mini_serv/test_miniserv.sh
+++ b/.subjects/STUD_PART/exam_06/0/mini_serv/test_miniserv.sh
@@ -18,7 +18,13 @@ if [ -e final ]; then
 
 sleep 1
 
-PORTOPEN=`ss -tuln | grep "$1"`
+if [ $(uname) == "Darwin" ]; then
+	PORTOPEN=`lsof -i -n -P | grep "$1"`
+	nc_command="nc localhost $1"
+else
+	PORTOPEN=`ss -tuln | grep "$1"`
+	nc_command="nc -q 0 localhost $1"
+fi
 
 # if it's open, then we can test the program
 if [ -z "$PORTOPEN" ]; then
@@ -40,27 +46,27 @@ bash catchmsg.sh $1 >> bim &
 
 sleep 1
 
-echo "Si vous ne voyez QUE ce message, c'est mauvais signe." | nc -q 0 localhost $1
+echo "Si vous ne voyez QUE ce message, c'est mauvais signe." | eval $nc_command
 sleep 0.2
-echo "Bienvenue sur le test de votre miniserv" | nc -q 0 localhost $1
+echo "Bienvenue sur le test de votre miniserv" | eval $nc_command
 sleep 0.2
-echo "Ceci est un message" | nc -q 0 localhost $1
+echo "Ceci est un message" | eval $nc_command
 sleep 0.2
-printf "Voici un texte sans retour a la ligne" | nc -q 0 localhost $1
+printf "Voici un texte sans retour a la ligne" | eval $nc_command
 sleep 0.2
-echo -n "This is a text without backline at the end" | nc -q 0 localhost $1
+echo -n "This is a text without backline at the end" | eval $nc_command
 sleep 0.4
-printf "Et voici un texte avec plusieurs\nretours\na\nla\nligne\n" | nc -q 0 localhost $1
+printf "Et voici un texte avec plusieurs\nretours\na\nla\nligne\n" | eval $nc_command
 sleep 0.2
 
 bash test_eof.sh $1
 sleep 1
 
-cat very_long_msg.txt | nc -q 0 localhost $1
+cat very_long_msg.txt | eval $nc_command
 
 sleep 1
 
-cat other_long_msg.txt | nc -q 0 localhost $1
+cat other_long_msg.txt | eval $nc_command
 
 sleep 2
 


### PR DESCRIPTION
When doing exam06 on MacOS, it raised an error because `ss` was not installed, it's a Linux tool, and can be replaced with `lsof`. 

`lsof` is also available on Linux but as I don't have any Linux computer right now to test, I decided to keep `ss` too. Same thing applies for `netcat`, macOS has a different version than Linux so I decided to use one or another depending on the OS.