### PR TITLE
Fixes and Improvements for ExamRank04

### DIFF
--- a/.subjects/STUD_PART/exam_04/0/microshell/microshell.c
+++ b/.subjects/STUD_PART/exam_04/0/microshell/microshell.c
@@ -167,10 +167,20 @@ void exec_cmd(t_base *temp, char **env)
 		exit_fatal();
 	else if (temp->pid == 0) //child
 	{
-		if (temp->type == TYPE_PIPE && dup2(temp->fd[STDOUT], STDOUT) < 0)
-			exit_fatal();
-		if (temp->prev && temp->prev->type == TYPE_PIPE && dup2(temp->prev->fd[STDIN], STDIN) < 0)
-			exit_fatal();
+		if (temp->type == TYPE_PIPE)
+		{
+			if (dup2(temp->fd[STDOUT], STDOUT) < 0)
+				exit_fatal();
+			if (close(temp->fd[STDIN]) || close(temp->fd[STDOUT]))
+				exit_fatal();
+		}
+		if (temp->prev && temp->prev->type == TYPE_PIPE)
+		{
+		 	if (dup2(temp->prev->fd[STDIN], STDIN) < 0)
+				exit_fatal();
+			if (close(temp->prev->fd[STDIN]))
+				exit_fatal();
+		}
 		if ((execve(temp->argv[0], temp->argv, env)) < 0)
 			exit_execve(temp->argv[0]);
 		exit(EXIT_SUCCESS);

--- a/.subjects/STUD_PART/exam_04/0/microshell/microshell.c
+++ b/.subjects/STUD_PART/exam_04/0/microshell/microshell.c
@@ -19,6 +19,7 @@ typedef struct s_base
     int size;
 	int type;
 	int fd[2];
+	pid_t pid;
 	struct s_base *prev;
     struct s_base *next;
 } t_base;
@@ -158,21 +159,13 @@ int parser_argv(t_base **ptr, char **av)
 
 void exec_cmd(t_base *temp, char **env)
 {
-	pid_t pid;
-	int status;
-	int pipe_open;
-
-	pipe_open = 0;
-	if (temp->type == TYPE_PIPE || (temp->prev && temp->prev->type == TYPE_PIPE))
-	{
-		pipe_open = 1;
+	if (temp->type == TYPE_PIPE)
 		if (pipe(temp->fd))
 			exit_fatal();
-	}
-	pid = fork();
-	if (pid < 0)
+	temp->pid = fork();
+	if (temp->pid < 0)
 		exit_fatal();
-	else if (pid == 0) //child
+	else if (temp->pid == 0) //child
 	{
 		if (temp->type == TYPE_PIPE && dup2(temp->fd[STDOUT], STDOUT) < 0)
 			exit_fatal();
@@ -184,13 +177,8 @@ void exec_cmd(t_base *temp, char **env)
 	}
 	else //parent
 	{
-		waitpid(pid, &status, 0);
-		if (pipe_open)
-		{
+		if (temp->type == TYPE_PIPE)
 			close(temp->fd[STDOUT]);
-			if (!temp->next || temp->type == TYPE_BREAK)
-				close(temp->fd[STDIN]);
-		}
 		if (temp->prev && temp->prev->type == TYPE_PIPE)
 			close(temp->prev->fd[STDIN]);
 	}
@@ -205,7 +193,7 @@ void exec_cmds(t_base *ptr, char **env)
 	{
 		if (strcmp("cd", temp->argv[0]) == 0)
 		{
-			if (temp->size < 2)
+			if (temp->size != 2)
 				exit_cd_1();
 			else if (chdir(temp->argv[1]))
 				exit_cd_2(temp->argv[1]);
@@ -216,28 +204,39 @@ void exec_cmds(t_base *ptr, char **env)
 	}
 }
 
+void wait_childs(t_base *temp)
+{
+	while (temp)
+	{
+		waitpid(temp->pid, NULL, 0);
+		temp = temp->next;
+	}
+}
+
 /*
 **====================================
 **============Part main===============
 **====================================
 */
 
-void free_all(t_base *ptr)
+void free_all(t_base **ptr)
 {
-	t_base *temp;
+	t_base *curr;
+	t_base *next;
 	int i;
 
-	while (ptr)
+	curr = *ptr;
+	while (curr)
 	{
-		temp = ptr->next;
+		next = curr->next;
 		i = 0;
-		while (i < ptr->size)
-			free(ptr->argv[i++]);
-		free(ptr->argv);
-		free(ptr);
-		ptr = temp;
+		while (i < curr->size)
+			free(curr->argv[i++]);
+		free(curr->argv);
+		free(curr);
+		curr = next;
 	}
-	ptr = NULL;
+	*ptr = NULL;
 }
 
 int main(int ac, char **av, char **env)
@@ -245,38 +244,37 @@ int main(int ac, char **av, char **env)
 	t_base *ptr = NULL;
 	int i;
 
+	if (ac == 1)
+		return (0);
 	i = 1;
-	if (ac > 1)
+	while (av[i]) //pipeline loop
 	{
-		while (av[i])
+		if (strcmp(av[i], ";") == 0)
+		{
+			i++;
+			continue ;
+		}
+		while (av[i] && strcmp(av[i], ";") != 0) //cmd loop
     	{
-            if (strcmp(av[i], ";") == 0)
-            {
-                i++;
-                continue ;
-            }
     	    i += parser_argv(&ptr, &av[i]);
-    	    if (!av[i])
-    	        break;
-    	    else
+    	    if (av[i] && !strcmp(av[i], "|"))
     	        i++;
     	}
-	/*while (ptr)
-	{
-		
-		printf("=================\n");
-		for (i = 0; i < ptr->size; i++)
-			printf("%s\n", ptr->argv[i]);
-		printf("TYPE: %d\n", ptr->type);
-		printf("SIZE: %d\n", ptr->size);
-		printf("=================\n");
-		ptr = ptr->next;
-	}
-	(void)**env;
-	printf("END\n");*/
-		if (ptr)
-			exec_cmds(ptr, env);
-		free_all(ptr);
+		/*while (ptr)
+		{
+			printf("=================\n");
+			for (i = 0; i < ptr->size; i++)
+				printf("%s\n", ptr->argv[i]);
+			printf("TYPE: %d\n", ptr->type);
+			printf("SIZE: %d\n", ptr->size);
+			printf("=================\n");
+			ptr = ptr->next;
+		}
+		(void)**env;
+		printf("END\n");*/
+		exec_cmds(ptr, env);
+		wait_childs(ptr);
+		free_all(&ptr);
 	}
 	return (0);
 }

--- a/.subjects/STUD_PART/exam_04/0/microshell/test.sh
+++ b/.subjects/STUD_PART/exam_04/0/microshell/test.sh
@@ -4,6 +4,8 @@ ulimit -n 30
 ./a.out /bin/ls microshell.c
 ./a.out /bin/ls salut
 ./a.out ";"
+./a.out ";abc"
+./a.out "|xyz"
 ./a.out ";" ";" ";" ";" ";" ";" ";" ";" ";" ";" ";" ";" ";" ";" ";" ";" ";" ";" ";" ";" ";" ";" ";"
 ./a.out ";" ";" /bin/echo OK
 ./a.out ";" ";" /bin/echo OK ";"
@@ -27,4 +29,75 @@ ulimit -n 30
 ./a.out blah "|" /bin/echo OK ";"
 ./a.out ";" ";" ";" ";" ";" ";" ";" ";" ";" ";" ";" ";" ";" ";" ";" ";" ";" ";" ";" ";" ";" blah "|" /bin/echo OK ";" ";" ";" ";" ";" ";" ";" ";" ";" ";" ";" ";" ";" ";" ";" ";" ";" ";" ";" ";" ";"
 ./a.out cd ";" /bin/ls
-./a.out /bin/ls "|" /usr/bin/grep microshell "|" /usr/bin/grep micro "|" /usr/bin/grep shell "|" /usr/bin/grep micro "|" /usr/bin/grep micro "|" /usr/bin/grep micro "|" /usr/bin/grep micro "|" /usr/bin/grep micro "|" /usr/bin/grep micro "|" /usr/bin/grep micro "|" /usr/bin/grep micro "|" /usr/bin/grep micro "|" /usr/bin/grep micro "|" /usr/bin/grep micro "|" /usr/bin/grep micro "|" /usr/bin/grep micro "|" /usr/bin/grep micro "|" /usr/bin/grep micro "|" /usr/bin/grep micro "|" /usr/bin/grep micro "|" /usr/bin/grep micro "|" /usr/bin/grep micro "|" /usr/bin/grep micro "|" /usr/bin/grep micro "|" /usr/bin/grep micro "|" /usr/bin/grep micro "|" /usr/bin/grep micro "|" /usr/bin/grep micro "|" /usr/bin/grep micro "|" /usr/bin/grep micro "|" /usr/bin/grep micro "|" /usr/bin/grep micro "|" /usr/bin/grep micro "|" /usr/bin/grep micro "|" /usr/bin/grep micro "|" /usr/bin/grep micro "|" /usr/bin/grep micro "|"
+./a.out cd a b c ";" /bin/ls
+./a.out cd ./non_existing_directory ";" /bin/ls
+./a.out cd_but_fake ";" /bin/ls
+./a.out /bin/pwd ";" cd ";" /bin/pwd ";" cd /root extra_arg2 extra_arg3 ";"
+./a.out ";" cd ./microshell ";" /bin/pwd ";" /bin/ls "|" /bin/grep microshell.c ";" cd .. ";" ";" /bin/pwd ";" ";"
+./a.out /bin/ls "|" /usr/bin/grep microshell "|" /usr/bin/grep micro "|" /usr/bin/grep shell "|" /usr/bin/grep micro "|" /usr/bin/grep micro "|" /usr/bin/grep micro "|" /usr/bin/grep micro "|" /usr/bin/grep micro "|" /usr/bin/grep micro "|" /usr/bin/grep micro "|" /usr/bin/grep micro "|" /usr/bin/grep micro "|" /usr/bin/grep micro "|" /usr/bin/grep micro "|" /usr/bin/grep micro "|" /usr/bin/grep micro "|" /usr/bin/grep micro "|" /usr/bin/grep micro "|" /usr/bin/grep micro "|" /usr/bin/grep micro "|" /usr/bin/grep micro "|" /usr/bin/grep micro "|" /usr/bin/grep micro "|" /usr/bin/grep micro "|" /usr/bin/grep micro "|" /usr/bin/grep micro "|" /usr/bin/grep micro "|" /usr/bin/grep micro "|" /usr/bin/grep micro "|" /usr/bin/grep micro "|" /usr/bin/grep micro "|" /usr/bin/grep micro "|" /usr/bin/grep micro "|" /usr/bin/grep micro "|" /usr/bin/grep micro "|" /usr/bin/grep micro "|" /usr/bin/grep micro
+
+KILLABLE_PNAME=/tmp/examrank04_killable.out
+pkill --signal SIGKILL -f $KILLABLE_PNAME
+cp a.out $KILLABLE_PNAME
+
+# waitpid right after every single fork
+($KILLABLE_PNAME /bin/sleep 2 "|" /bin/echo "#test_1 This line should be printed 1st" &)
+sleep 1
+./a.out /bin/echo "#test_1 This line should be printed 2nd"
+sleep 1
+pkill --signal SIGKILL -f $KILLABLE_PNAME
+
+# no waitpid at all
+(./a.out /bin/sleep 2 ";" /bin/echo "#test_2 This line should be printed 2nd" &)
+sleep 1
+./a.out /bin/echo "#test_2 This line should be printed 1st"
+sleep 1
+pkill --signal SIGKILL -f $KILLABLE_PNAME
+
+GPC_SOURCE=/tmp/get_pipe_capacity.c
+GPC_BINARY=/tmp/get_pipe_capacity.out
+PIPE_FILLER=/tmp/pipe_filler
+cat > $GPC_SOURCE << EOF
+#define _GNU_SOURCE
+#include <unistd.h>
+#include <fcntl.h>
+#include <stdio.h>
+
+int	main(void)
+{
+	int	fd[2];
+
+	pipe(fd);
+	printf("%d\n", fcntl(fd[0], F_GETPIPE_SZ));
+}
+EOF
+
+# creates a file that can fill up the pipe buffer capacity and has 1 extra byte that blocks final write
+test_full_pipe_buffer()
+{
+	gcc $GPC_SOURCE -o $GPC_BINARY #> /dev/null 2>&1
+	PIPE_CAPACITY=$($GPC_BINARY)
+	PIPE_CAPACITY_P1=$(($PIPE_CAPACITY + 1))
+	dd if=/dev/zero of=$PIPE_FILLER bs=1 count=$PIPE_CAPACITY_P1 > /dev/null 2>&1
+
+	cp a.out $KILLABLE_PNAME
+	($KILLABLE_PNAME /bin/cat $PIPE_FILLER "|" /bin/tee /dev/null &)
+	# assumptions:
+	# 1 - 'cat' can write all the bytes into the pipe and 'tee' can read all of them then both cmds exit. all under 1 second
+	# 2 - process uses waitpid() properly (last 2 checks above)
+	sleep 1 
+	PC_PGREP_OUTPUT=$(pgrep -f $KILLABLE_PNAME)
+	if [ -z $PC_PGREP_OUTPUT ]; then
+		echo "test_full_pipe_buffer: OK (Program doesn't rely on pipe buffer capacity)"
+	else
+		echo "test_full_pipe_buffer: KO (Program does    rely on pipe buffer capacity (Hint: Pipes need to get read from)"
+		pkill -f /bin/cat
+	fi
+}
+
+test_full_pipe_buffer
+pkill --signal SIGKILL -f $KILLABLE_PNAME
+rm -f $KILLABLE_PNAME
+rm -f $GPC_SOURCE
+rm -f $GPC_BINARY
+rm -f $PIPE_FILLER


### PR DESCRIPTION
# Fixes
### test.sh
- Removed the "|" at the end of the last test which clearly violated subject.txt (*followed by nothing*)
> we will never try a "|" immediately followed or preceded by nothing or "|" or ";"
- *cd* wouldn't fail if it had more than 1 args
### microshell.c 
- By executing one command at a time:
-> All the commands in the same **pipeline** that should have started at the same time would wait one before themself to finish executing
-> Code would rely on pipe buffer capacity
-> free_all() wasn't actually assigning NULL to the *ptr* but to the local variable (misunderstanding of how pointers work)
- Now all commands in the same **pipeline** get executed and then get waitpid()'ed. free_all() works as intended.
- Fixed fd leak right before executing the programs which lets writers continue writing to a pipe instead of causing them to get SIGPIPE and terminate (in a normal scenario where all read ends of a pipe is closed). Both read and write ends were leaking.

# Improvements
### test.sh
- Added more *cd* tests for errors
- Added cases ";abc" and "|xyz" to test string comparison
- Added 2 tests to check if **waitpid()** is used properly
-> **waitpid()** right after every fork should fail
-> Not using **waitpid()** at all should fail
- A function to create and serve a file that can fill up a pipe buffer and block final write (This is also **indirectly** testing if waitpid is used properly in a more complex format)
- Added fd leak test
### microshell.c
- Removed (seemingly) unnecessary checks when creating and closing pipes
- Changed main algorithm to execute commands in a pipeline all at once

# Notes
- I am not really a big fan of making a lot of assumptions for a code to work properly. Some of the tests I have added may not work if something lags for a second or so
- There might be better ways to trace fork() and waitpid() system calls
- I am not really sure if leaving hints and some explanations on **test.sh** would be ok as it is also shown in traces
- **Need more testing especially on MacOS**
```
git clone https://github.com/hcivici/42_EXAM.git 42_EXAM_test_hcivici && cd 42_EXAM_test_hcivici && make
```