### PR TITLE
fix: exam06

### DIFF
--- a/.subjects/STUD_PART/exam_06/0/mini_serv/catchmsg.sh
+++ b/.subjects/STUD_PART/exam_06/0/mini_serv/catchmsg.sh
@@ -6,5 +6,5 @@ exec 6</dev/tcp/localhost/"$1"
 
 while read -r <&6
 do
-    echo "$REPLY" >> bim
+    echo "$REPLY"
 done


### PR DESCRIPTION
the one write to the `bim` file was overwriting the other one, ending up with an empty file that always failed the tests.